### PR TITLE
Add option to specify MumbleLink name

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use core::fmt;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! Provides an abstraction over Mumblelink for Windows and Unix like systems
 
-pub mod mumble_link;
 pub mod error;
-#[cfg_attr(windows, path="windows_mumble_link_handler.rs")]
-#[cfg_attr(unix, path="unix_mumble_link_handler.rs")]
+pub mod mumble_link;
+#[cfg_attr(windows, path = "windows_mumble_link_handler.rs")]
+#[cfg_attr(unix, path = "unix_mumble_link_handler.rs")]
 pub mod mumble_link_handler;
 mod unix_mumble_link_handler;
 

--- a/src/mumble_link.rs
+++ b/src/mumble_link.rs
@@ -9,8 +9,8 @@ use winapi::{
     um::{
         handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
         memoryapi::FILE_MAP_ALL_ACCESS,
-        winnt::{HANDLE, PAGE_READWRITE}
-    }
+        winnt::{HANDLE, PAGE_READWRITE},
+    },
 };
 
 use crate::error::MumbleLinkHandlerError;
@@ -20,7 +20,7 @@ use libc::wchar_t;
 #[cfg(all(windows))]
 fn wchar_t_to_string(src: &[wchar_t]) -> String {
     let zero = src.iter().position(|&c| c == 0).unwrap_or(src.len());
-     String::from_utf16_lossy(&src[..zero])
+    String::from_utf16_lossy(&src[..zero])
 }
 
 #[cfg(all(unix))]
@@ -106,7 +106,9 @@ impl CMumbleLinkData {
 }
 
 impl Clone for CMumbleLinkData {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/unix_mumble_link_handler.rs
+++ b/src/unix_mumble_link_handler.rs
@@ -54,7 +54,7 @@ impl MumbleLinkHandler {
 
     /// Create new MumbleLinkHandler
     pub fn new() -> std::result::Result<MumbleLinkHandler, MumbleLinkHandlerError> {
-        Self::create("MumbleLink")
+        Self::with_name("MumbleLink")
     }
 }
 

--- a/src/unix_mumble_link_handler.rs
+++ b/src/unix_mumble_link_handler.rs
@@ -1,8 +1,8 @@
-use crate::mumble_link::{MumbleLinkReader, MumbleLinkData, CMumbleLinkData};
 use crate::error::MumbleLinkHandlerError;
-use std::io;
+use crate::mumble_link::{CMumbleLinkData, MumbleLinkData, MumbleLinkReader};
 use core::ptr;
 use std::ffi::CString;
+use std::io;
 use std::os::raw::c_uint;
 
 #[cfg(all(unix))]
@@ -13,10 +13,12 @@ pub struct MumbleLinkHandler {
 
 #[cfg(all(unix))]
 impl MumbleLinkHandler {
-    pub fn new() -> std::result::Result<MumbleLinkHandler, MumbleLinkHandlerError> {
+    /// Create new MumbleLinkHandler with specified name
+    pub fn with_name(name: &str) -> std::result::Result<MumbleLinkHandler, MumbleLinkHandlerError> {
         let uid = unsafe { libc::getuid() };
         let MUMBLE_LINK_STRUCT_SIZE: i64 = std::mem::size_of::<CMumbleLinkData>() as i64;
-        let MMAP_PATH: CString = CString::new(format!("/MumbleLink.{}", uid)).expect("Failed to create MMAP_PATH");
+        let MMAP_PATH: CString =
+            CString::new(format!("/{}.{}", name, uid)).expect("Failed to create MMAP_PATH");
         unsafe {
             let mut fd = libc::shm_open(
                 MMAP_PATH.as_ptr(),
@@ -29,7 +31,7 @@ impl MumbleLinkHandler {
                     libc::O_CREAT,
                     libc::S_IRUSR as c_uint | libc::S_IWUSR as c_uint,
                 );
-                let trunc: i32 = unsafe{libc::ftruncate(fd, MUMBLE_LINK_STRUCT_SIZE)};
+                let trunc: i32 = unsafe { libc::ftruncate(fd, MUMBLE_LINK_STRUCT_SIZE) };
                 if trunc < 0 || fd < 0 {
                     return Err(MumbleLinkHandlerError::OSError(io::Error::last_os_error()));
                 }
@@ -46,11 +48,13 @@ impl MumbleLinkHandler {
                 libc::close(fd);
                 return Err(MumbleLinkHandlerError::OSError(io::Error::last_os_error()));
             }
-            Ok(MumbleLinkHandler {
-                fd: fd,
-                ptr: ptr,
-            })
+            Ok(MumbleLinkHandler { fd: fd, ptr: ptr })
         }
+    }
+
+    /// Create new MumbleLinkHandler
+    pub fn new() -> std::result::Result<MumbleLinkHandler, MumbleLinkHandlerError> {
+        Self::create("MumbleLink")
     }
 }
 


### PR DESCRIPTION
this adds a `MumbleLinkHandler::with_name` function which allows you to specify your own `MumbleLink` name

Also ran `cargo fmt`

Not sure about the Linux part, since I just tested this on Windows